### PR TITLE
Fix OpenIdentityPlatform#270 part 1 - Remove hardcoded CSS class for ReCaptcha in self service components

### DIFF
--- a/ui/user/src/main/resources/templates/user/process/registration/captcha-initial.html
+++ b/ui/user/src/main/resources/templates/user/process/registration/captcha-initial.html
@@ -9,12 +9,6 @@ function handleCaptchaCallback(response) {
 }
 </script>
 
-<style>
-.g-recaptcha>div>div {
-    display: inline-block;
-}
-</style>
-
 <div class="g-recaptcha"
     data-sitekey="{{requirements.properties.response.recaptchaSiteKey}}"
     data-callback="handleCaptchaCallback"></div>

--- a/ui/user/src/main/resources/templates/user/process/reset/captcha-initial.html
+++ b/ui/user/src/main/resources/templates/user/process/reset/captcha-initial.html
@@ -9,12 +9,6 @@ function handleCaptchaCallback(response) {
 }
 </script>
 
-<style>
-.g-recaptcha>div>div {
-    display: inline-block;
-}
-</style>
-
 <div class="g-recaptcha"
     data-sitekey="{{requirements.properties.response.recaptchaSiteKey}}"
     data-callback="handleCaptchaCallback"></div>

--- a/ui/user/src/main/resources/templates/user/process/username/captcha-initial.html
+++ b/ui/user/src/main/resources/templates/user/process/username/captcha-initial.html
@@ -9,12 +9,6 @@ function handleCaptchaCallback(response) {
 }
 </script>
 
-<style>
-.g-recaptcha>div>div {
-    display: inline-block;
-}
-</style>
-
 <div class="g-recaptcha"
     data-sitekey="{{requirements.properties.response.recaptchaSiteKey}}"
     data-callback="handleCaptchaCallback"></div>


### PR DESCRIPTION
This commit to commons goes together with the other pull request in project OpenAM to let the user style the appearance of the self service ReCaptcha via its theme files.