### PR TITLE
 2.3.3->3.0.9 Groovy CVE-2020-17521

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@
 [![Deploy](https://github.com/OpenIdentityPlatform/commons/actions/workflows/deploy.yml/badge.svg)](https://github.com/OpenIdentityPlatform/commons/actions/workflows/deploy.yml)
 ## How-to build
 
+
+[![Build Maven](https://github.com/artb1sh/commons/actions/workflows/build.yml/badge.svg)](https://github.com/artb1sh/commons/actions/workflows/build.yml)
+
 * git clone --recursive  https://github.com/OpenIdentityPlatform/commons.git
 * mvn clean install -f commons

--- a/README.md
+++ b/README.md
@@ -3,8 +3,5 @@
 [![Deploy](https://github.com/OpenIdentityPlatform/commons/actions/workflows/deploy.yml/badge.svg)](https://github.com/OpenIdentityPlatform/commons/actions/workflows/deploy.yml)
 ## How-to build
 
-
-[![Build Maven](https://github.com/artb1sh/commons/actions/workflows/build.yml/badge.svg)](https://github.com/artb1sh/commons/actions/workflows/build.yml)
-
 * git clone --recursive  https://github.com/OpenIdentityPlatform/commons.git
 * mvn clean install -f commons

--- a/commons/http-framework/core/pom.xml
+++ b/commons/http-framework/core/pom.xml
@@ -28,6 +28,11 @@
   <name>${project.groupId}.${project.artifactId}</name>
   <dependencies>
     <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>3.0.9</version>
+     </dependency>
+    <dependency>
       <groupId>org.openidentityplatform.commons</groupId>
       <artifactId>util</artifactId>
     </dependency>

--- a/commons/http-framework/core/pom.xml
+++ b/commons/http-framework/core/pom.xml
@@ -28,11 +28,6 @@
   <name>${project.groupId}.${project.artifactId}</name>
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy</artifactId>
-      <version>3.0.9</version>
-     </dependency>
-    <dependency>
       <groupId>org.openidentityplatform.commons</groupId>
       <artifactId>util</artifactId>
     </dependency>
@@ -81,7 +76,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-jsr223</artifactId>
-      <version>2.3.3</version>
+      <version>3.0.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
CVE-2020-17521
Description from CVE
Apache Groovy provides extension methods to aid with creating temporary directories. Prior to this fix, Groovy's implementation of those extension methods was using a now superseded Java JDK method call that is potentially not secure on some operating systems in some contexts. Users not using the extension methods mentioned in the advisory are not affected, but may wish to read the advisory for further details. Versions Affected: 2.0 to 2.4.20, 2.5.0 to 2.5.13, 3.0.0 to 3.0.6, and 4.0.0-alpha-1. Fixed in versions 2.4.21, 2.5.14, 3.0.7, 4.0.0-alpha-2.
Reference: https://groovy-lang.org/security.html#CVE-2020-1