### PR TITLE
Bump jetty-server from 8.1.15.v20140411 to 9.4.45.v20220203

### DIFF
--- a/commons/http-framework/servlet/pom.xml
+++ b/commons/http-framework/servlet/pom.xml
@@ -64,13 +64,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.15.v20140411</version>
+      <version>9.4.45.v20220203</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.15.v20140411</version>
+      <version>9.4.45.v20220203</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/commons/http-framework/servlet/src/test/java/org/forgerock/http/servlet/ServletTest.java
+++ b/commons/http-framework/servlet/src/test/java/org/forgerock/http/servlet/ServletTest.java
@@ -15,6 +15,7 @@
  */
 package org.forgerock.http.servlet;
 
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -37,7 +38,7 @@ public class ServletTest extends BindingTest {
     @Override
     protected int startServer() throws Exception {
         server.start();
-        return server.getConnectors()[0].getLocalPort();
+        return ((NetworkConnector)server.getConnectors()[0]).getLocalPort();
     }
 
     @Override


### PR DESCRIPTION
Bump jetty-server from 8.1.15.v20140411 to 9.4.45.v20220203 in /commons/http-framework/servlet