### PR TITLE
FIX Guava vulnerable to insecure use of temporary directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>31.1-jre</version>
+				<version>32.1.1-jre</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Use of Java's default temporary directory for file creation in FileBackedOutputStream in Google Guava versions 1.0 to 31.1 on Unix systems and Android Ice Cream Sandwich allows other users and apps on the machine with access to the default Java temporary directory to be able to access the files created by the class.

Even though the security vulnerability is fixed in version 32.0.0, maintainers recommend using version 32.0.1 as version 32.0.0 breaks some functionality under Windows.