### PR TITLE
Bump jetty to 9.4.51.v20230217

### DIFF
--- a/commons/http-framework/servlet/pom.xml
+++ b/commons/http-framework/servlet/pom.xml
@@ -64,13 +64,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.51.v20230217</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.51.v20230217</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
OutOfMemoryError for large multipart without filename in Eclipse Jetty
Eclipse Jetty's cookie parsing of quoted values can exfiltrate values
from other cookies