### PR TITLE
Set javax.servlet version in the dependency management section

### DIFF
--- a/commons/audit/pom.xml
+++ b/commons/audit/pom.xml
@@ -77,7 +77,6 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>${servlet-api.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/commons/auth-filters/authz-filter/framework-functional-tests/pom.xml
+++ b/commons/auth-filters/authz-filter/framework-functional-tests/pom.xml
@@ -176,8 +176,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/commons/httpdump/pom.xml
+++ b/commons/httpdump/pom.xml
@@ -15,9 +15,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
-			<type>jar</type>
+			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.MessageFormat;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -79,7 +80,27 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
         public synchronized void reset() throws IOException {
             throw new IOException("mark/reset not supported");
         }
-    }
+
+		@Override
+		public boolean isFinished() {
+            try {
+                return is.available() == 0;
+            } catch (IOException e) {
+				logger.warn(e.getMessage());
+            }
+			return false;
+        }
+
+		@Override
+		public boolean isReady() {
+			return true;
+		}
+
+		@Override
+		public void setReadListener(ReadListener readListener) {
+			throw new UnsupportedOperationException();
+		}
+	}
     
     public String getRequestBody() {
     	readBody();

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2020-2025 3A Systems LLC.
+ */
+
 package ru.org.openam.httpdump;
 
 import java.io.BufferedReader;
@@ -18,43 +34,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BufferedRequestWrapper extends HttpServletRequestWrapper {
-	final static Logger logger = LoggerFactory.getLogger(BufferedRequestWrapper.class.getName());
-	byte[] body=null;
+    final static Logger logger = LoggerFactory.getLogger(BufferedRequestWrapper.class.getName());
+    byte[] body = null;
 
     public BufferedRequestWrapper(HttpServletRequest httpServletRequest) {
         super(httpServletRequest);
         setAttribute(BufferedRequestWrapper.class.getName(), this);
     }
 
-    private void readBody(){
-    	if (body==null 
-    			&& !StringUtils.containsIgnoreCase(getContentType(), "application/x-www-form-urlencoded")
-    			&& !StringUtils.containsIgnoreCase(getContentType(), "multipart/form-data")
-    		)
-	    	try{
-	 	        InputStream is = super.getInputStream();
-	 	        body = IOUtils.toByteArray(is);
-	 	        is.close();
-	         }catch(IOException e){
-	         	logger.warn("{}: {}",e.getMessage(),Dump.toString(getRequest()));
-	         }
+    private void readBody() {
+        if (body == null
+                && !StringUtils.containsIgnoreCase(getContentType(), "application/x-www-form-urlencoded")
+                && !StringUtils.containsIgnoreCase(getContentType(), "multipart/form-data")
+        )
+            try {
+                InputStream is = super.getInputStream();
+                body = IOUtils.toByteArray(is);
+                is.close();
+            } catch (IOException e) {
+                logger.warn("{}: {}", e.getMessage(), Dump.toString(getRequest()));
+            }
     }
-    
+
     @Override
     public ServletInputStream getInputStream() throws IOException {
-    	readBody();
-    	if (body==null)
-    		return super.getInputStream();
-    	return new ServletInputStreamImpl(new ByteArrayInputStream(body));
+        readBody();
+        if (body == null)
+            return super.getInputStream();
+        return new ServletInputStreamImpl(new ByteArrayInputStream(body));
     }
 
     @Override
     public BufferedReader getReader() throws IOException {
-    	readBody();
-    	if (body==null)
-    		return super.getReader();
+        readBody();
+        if (body == null)
+            return super.getReader();
         String enc = getCharacterEncoding();
-        if(enc == null) enc = "UTF-8";
+        if (enc == null) enc = "UTF-8";
         return new BufferedReader(new InputStreamReader(getInputStream(), enc));
     }
 
@@ -74,45 +90,45 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
         }
 
         @Override
-		public boolean isFinished() {
+        public boolean isFinished() {
             try {
                 return is.available() == 0;
             } catch (IOException e) {
-				logger.warn(e.getMessage());
+                logger.warn(e.getMessage());
             }
-			return false;
+            return false;
         }
 
-		@Override
-		public boolean isReady() {
-			return true;
-		}
+        @Override
+        public boolean isReady() {
+            return true;
+        }
 
-		@Override
-		public void setReadListener(ReadListener readListener) {
-			throw new UnsupportedOperationException();
-		}
-	}
-    
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     public String getRequestBody() {
-    	readBody();
-    	if (body==null)
-    		return MessageFormat.format("{0}:{1}", getContentType(),getContentLength());
-		try{
-	    	BufferedReader reader = getReader();
-			String line = null;
-			StringBuilder inputBuffer = new StringBuilder();
-			do {
-				line = reader.readLine();
-				if (null != line) 
-					inputBuffer.append(line.trim());
-			} while (line != null);
-			reader.close();
-			return inputBuffer.toString().trim();
-		}catch (IOException e) {
-			return null;
-		}
-	}
+        readBody();
+        if (body == null)
+            return MessageFormat.format("{0}:{1}", getContentType(), getContentLength());
+        try {
+            BufferedReader reader = getReader();
+            String line = null;
+            StringBuilder inputBuffer = new StringBuilder();
+            do {
+                line = reader.readLine();
+                if (null != line)
+                    inputBuffer.append(line.trim());
+            } while (line != null);
+            reader.close();
+            return inputBuffer.toString().trim();
+        } catch (IOException e) {
+            return null;
+        }
+    }
 
 }
 

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
@@ -69,19 +69,11 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
             return is.read();
         }
 
-        public boolean markSupported() {
-            return false;
-        }
-
         public synchronized void mark(int i) {
             throw new RuntimeException(new IOException("mark/reset not supported"));
         }
 
-        public synchronized void reset() throws IOException {
-            throw new IOException("mark/reset not supported");
-        }
-
-		@Override
+        @Override
 		public boolean isFinished() {
             try {
                 return is.available() == 0;

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/Dump.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/Dump.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2020-2025 3A Systems LLC.
+ */
+
 package ru.org.openam.httpdump;
 
 import java.text.MessageFormat;

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/Filter.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/Filter.java
@@ -1,4 +1,19 @@
 package ru.org.openam.httpdump;
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2020-2025 3A Systems LLC.
+ */
 
 import java.io.IOException;
 

--- a/commons/httpdump/src/test/java/Test.java
+++ b/commons/httpdump/src/test/java/Test.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2020-2025 3A Systems LLC.
+ */
+
 import org.junit.Ignore;
 
 import ru.org.openam.geo.Client;

--- a/commons/rest/json-resource-http/pom.xml
+++ b/commons/rest/json-resource-http/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <swagger.version>1.6.11</swagger.version>
         <rhino.version>1.7.14</rhino.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
-        <grizzly-framework.version>2.4.4</grizzly-framework.version>
+        <grizzly-framework.version>2.3.17</grizzly-framework.version>
     </properties>
 
     <prerequisites>
@@ -691,7 +691,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>4.0.1</version>
+                <version>3.1.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -691,7 +691,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.1.0</version>
+                <version>4.0.1</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -883,7 +883,11 @@
                 <artifactId>grizzly-http-servlet</artifactId>
                 <version>${grizzly-framework.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.glassfish.grizzly</groupId>
+                <artifactId>grizzly-websockets</artifactId>
+                <version>${grizzly-framework.version}</version>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
     <build><finalName>${project.groupId}.${project.artifactId}</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <swagger.version>1.6.11</swagger.version>
         <rhino.version>1.7.14</rhino.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
-        <grizzly-framework.version>2.3.17</grizzly-framework.version>
+        <grizzly-framework.version>2.3.35</grizzly-framework.version>
     </properties>
 
     <prerequisites>


### PR DESCRIPTION
downgraded grizzly-framework to keep compatibility with servlet 3.1 for OpenICF + OpenIDM

